### PR TITLE
Migrate to .net 6.0, Fix some issues to deploy on Linux

### DIFF
--- a/Gapita.csproj
+++ b/Gapita.csproj
@@ -1,13 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-  </ItemGroup>
 
 </Project>

--- a/Startup.cs
+++ b/Startup.cs
@@ -29,10 +29,11 @@ namespace Gapita
 
             app.UseDefaultFiles();
             app.UseStaticFiles();
+            app.UseRouting(); 
 
-            app.UseSignalR(options =>
+            app.UseEndpoints(endpoints =>
             {
-                options.MapHub<GapitaHub>("/hub/GapitaHub");
+                endpoints.MapHub<GapitaHub>("/hub/GapitaHub");
             });
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Gapita",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": true,
   "description": "An anonymous and random chat messaging for talking to strangers",
   "main": "index.js",

--- a/src/chatfunc.ts
+++ b/src/chatfunc.ts
@@ -1,5 +1,5 @@
 import * as signalR from "@aspnet/signalr";
-import * as $ from "Jquery";
+import * as $ from "jquery";
 
 // Initialize
 const txtOnlineUsers: HTMLParagraphElement = document.querySelector("#txtOnlineUsers");


### PR DESCRIPTION
After a long time,
GAPITA migrated to `.net 6.0`. Also, refers to #41, I fixed some issues in deploying on **Linux**.